### PR TITLE
MenuXDGCheck: explicitly specify utf-8 encoding

### DIFF
--- a/MenuXDGCheck.py
+++ b/MenuXDGCheck.py
@@ -30,7 +30,7 @@ class MenuXDGCheck(AbstractCheck.AbstractFilesCheck):
     def parse_desktop_file(self, pkg, root, f, filename):
         cfp = cfgparser.RawConfigParser()
         try:
-            with open(f) as inputf:
+            with open(f, encoding='utf-8') as inputf:
                 cfp.readfp(inputf, filename)
         except cfgparser.DuplicateSectionError as e:
             printError(


### PR DESCRIPTION
Encoding defaults to ascii when using the C locale, any non-ascii
character throws a UnicodeDecodeError exception.